### PR TITLE
[Pull Request] Newline Bug (Item.Description)

### DIFF
--- a/src/client/commands/item.js
+++ b/src/client/commands/item.js
@@ -19,7 +19,9 @@ module.exports = {
   cooldown: 5000 / Second,
   build(item) {
     const title = item.Name;
-    const description = item.Description || "No description provided.";
+    const description =
+      item.Description.replace(/(\r\n|\r|\n){2,}/g, "$1\n") ||
+      "No description provided.";
 
     let thumbnail;
     if (item.IconHD || item.Icon)


### PR DESCRIPTION
Fixed a cosmetic bug where Miqo displays multiple newlines from an item's description text when fetched from [XIVAPI](https://xivapi.com/ 'XIVAPI - A FINAL FANTASY XIV: Online REST API'). 🐞

## Before

```javascript
const description = item.Description;
```

![](https://pbs.twimg.com/media/Fza75PnXoAEOiDf?format=png&name=small)

## After

```javascript
const description = item.Description.replace(/(\r\n|\r|\n){2,}/g, "$1\n") || "No description provided.";
```

![](https://pbs.twimg.com/media/Fza75yCWAAQP7R6?format=png&name=small)